### PR TITLE
Modify the game log to accept and display the source of boost events

### DIFF
--- a/scenes/game/game.gd
+++ b/scenes/game/game.gd
@@ -822,14 +822,25 @@ func _on_boost_stat_event(event_data):
 	var stat = event_data["stat"]
 	var amount = event_data["amount"]
 	var for_art = event_data["for_art"]
+	var source_card_id = event_data["source_card_id"] if event_data.has("source_card_id") else ""
+
 	var card_str = ""
 	if card_id:
 		card_str = "[CARD]%s[/CARD] " % _get_card_definition_id(card_id)
+
+	var skill_str = ""
+	if source_card_id:
+		skill_str = "[SKILLSOURCE]%s|%s[/SKILLSOURCE]" % [
+			_get_card_definition_id(source_card_id),
+			Strings.get_stat_string(stat)]
+	else:
+		skill_str = "[SKILL]%s[/SKILL]" % Strings.get_stat_string(stat)
+
 	# TODO: Animation - show stat boost.
-	game_log.add_to_log(GameLog.GameLogLine.Detail, "%s+%s [SKILL]%s[/SKILL] " % [
+	game_log.add_to_log(GameLog.GameLogLine.Detail, "%s+%s %s " % [
 		card_str,
 		amount,
-		Strings.get_stat_string(stat),
+		skill_str
 	])
 
 	if for_art:

--- a/scenes/game/game_log.gd
+++ b/scenes/game/game_log.gd
@@ -45,6 +45,18 @@ func add_to_log(log_type, text : String):
 		var end = text.find("[/CARD]", start)
 		var card_id = text.substr(start, end - start)
 		text = text.replace("[CARD]%s[/CARD]" % [card_id], "[url=%s][CARDCOLORTAG]%s[/CARDCOLORTAG][/url]" % [card_id, card_id])
+
+	# Perform the same for [SKILLSOURCE] tag
+	while text.find("[SKILLSOURCE]") != -1:
+		var start = text.find("[SKILLSOURCE]") + 13
+		var end = text.find("[/SKILLSOURCE]", start)
+		var content_text = text.substr(start, end - start)
+		var content_items = Array(content_text.split("|")) # [source_card_id, stat]
+		text = text.replace(
+			"[SKILLSOURCE]%s[/SKILLSOURCE]" % content_text,
+			"[url=?][SKILL]?[/SKILL][/url]".format(content_items, "?")
+		)
+
 	text = replace_tag(text, "CARDCOLORTAG", CARD_COLOR)
 	text = replace_tag(text, "PHASE", PHASE_COLOR)
 	text = replace_tag(text, "DECISION", DECISION_COLOR)


### PR DESCRIPTION
Extended the game log to also respond to hover events for a boost event i.e. ( ``Power``, ``Additional Damage``, and ``Damage Prevented``) like how it currently does for card ids.

The changes in this PR do not strictly rely on the availability of the added changes to the server repo (daniel-k-taylor/holocardserver#24) and will default back to the previous behavior.

<img width="750" alt="Screenshot 2024-10-10 at 20 13 43" src="https://github.com/user-attachments/assets/caff1bd3-bb8c-48b5-8be5-57f7c07d7f9c">